### PR TITLE
Adding a demo notebook to demonstrate PoC on running dask cluster.

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import inotify\n",
+    "except ImportError as e:\n",
+    "    !pip install inotify"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "import subprocess as subp\n",
+    "import os\n",
+    "import dask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import inotify.adapters\n",
+    "\n",
+    "def create_ompi_server(uri_file):\n",
+    "\n",
+    "    cmd = [\"ompi-server\", \"--no-daemonize\",\"-r\", uri_file]\n",
+    "    cmdStr = \"exec \" + \" \".join(cmd)\n",
+    "    \n",
+    "    i = inotify.adapters.Inotify()\n",
+    "    \n",
+    "    with open(uri_file, 'w') as f:\n",
+    "        pass\n",
+    "    \n",
+    "    \n",
+    "    i.add_watch(uri_file)\n",
+    "\n",
+    "    proc = subp.Popen(cmdStr, shell=True)\n",
+    "\n",
+    "    for event in i.event_gen(yield_nones=False):\n",
+    "        (_, type_names, path, filename) = event\n",
+    "        if \"IN_CLOSE_WRITE\" in type_names:\n",
+    "            break\n",
+    "    \n",
+    "    \n",
+    "    i.remove_watch(uri_file)\n",
+    "\n",
+    "    \n",
+    "    mpiServer = proc\n",
+    "    import time\n",
+    "    with open(uri_file, \"r\") as fp:\n",
+    "        mpiServerUri = fp.read().rstrip()\n",
+    "        \n",
+    "    return (mpiServer, mpiServerUri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uriFile = \"ompi.server.uri\"\n",
+    "\n",
+    "mpiServer, mpiServerUri = create_ompi_server(uriFile)\n",
+    "os.environ[\"OMPI_MCA_pmix_server_uri\"] = mpiServerUri"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask_cuda import LocalCUDACluster\n",
+    "cluster = LocalCUDACluster()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3>Client</h3>\n",
+       "<ul>\n",
+       "  <li><b>Scheduler: </b>tcp://127.0.0.1:39731\n",
+       "  <li><b>Dashboard: </b><a href='http://127.0.0.1:8787/status' target='_blank'>http://127.0.0.1:8787/status</a>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3>Cluster</h3>\n",
+       "<ul>\n",
+       "  <li><b>Workers: </b>2</li>\n",
+       "  <li><b>Cores: </b>2</li>\n",
+       "  <li><b>Memory: </b>50.39 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Client: scheduler='tcp://127.0.0.1:39731' processes=2 cores=2>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c = Client(cluster)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hello_mpi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def parse_host_port(address):\n",
+    "    if '://' in address:\n",
+    "        address = address.rsplit('://', 1)[1]\n",
+    "    host, port = address.split(':')\n",
+    "    port = int(port)\n",
+    "    return host, port"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run(workerId, nWorkers, ompiServerUri):\n",
+    "    if ompiServerUri is None:\n",
+    "        raise Exception(\"ompiServerUri is mandatory!\")\n",
+    "    os.environ[\"OMPI_MCA_pmix_server_uri\"] = ompiServerUri\n",
+    "    w = dask.distributed.get_worker()\n",
+    "    print(\"Hello World! from ip=%s worker=%s/%d uri=%s\" % \\\n",
+    "          (w.address, w.name, nWorkers, ompiServerUri))\n",
+    "    print(\"Worker=%s finished\" % w.name)\n",
+    "    \n",
+    "    a = hello_mpi.World(workerId, nWorkers)\n",
+    "    a.init()\n",
+    "\n",
+    "    return a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workers = list(zip(map(lambda x: parse_host_port(x), c.has_what().keys()), range(len(c.has_what().keys()))))\n",
+    "f = [c.submit(run, idx, 2, mpiServerUri, workers=[worker]) for worker, idx in workers]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "def get_rank(world, r):\n",
+    "    return world.rank()\n",
+    "\n",
+    "def finalize(world):\n",
+    "    world.finalize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "ranks = [c.submit(get_rank, a, random.random()) for a in f]\n",
+    "for i in ranks:\n",
+    "    print(str(i.result()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Future: status: pending, key: finalize-29b8800f27d460d460363a125011ab3d>,\n",
+       " <Future: status: pending, key: finalize-368dc52407099ed523252fd85db31617>]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[c.submit(finalize, a) for a in f]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mpiServer.kill()\n",
+    "os.remove(uriFile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (cuml4)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -21,64 +21,13 @@
     "from dask.distributed import Client\n",
     "import subprocess as subp\n",
     "import os\n",
-    "import dask"
+    "import dask\n",
+    "import inotify.adapters\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import inotify.adapters\n",
-    "\n",
-    "def create_ompi_server(uri_file):\n",
-    "\n",
-    "    cmd = [\"ompi-server\", \"--no-daemonize\",\"-r\", uri_file]\n",
-    "    cmdStr = \"exec \" + \" \".join(cmd)\n",
-    "    \n",
-    "    i = inotify.adapters.Inotify()\n",
-    "    \n",
-    "    with open(uri_file, 'w') as f:\n",
-    "        pass\n",
-    "    \n",
-    "    \n",
-    "    i.add_watch(uri_file)\n",
-    "\n",
-    "    proc = subp.Popen(cmdStr, shell=True)\n",
-    "\n",
-    "    for event in i.event_gen(yield_nones=False):\n",
-    "        (_, type_names, path, filename) = event\n",
-    "        if \"IN_CLOSE_WRITE\" in type_names:\n",
-    "            break\n",
-    "    \n",
-    "    \n",
-    "    i.remove_watch(uri_file)\n",
-    "\n",
-    "    \n",
-    "    mpiServer = proc\n",
-    "    import time\n",
-    "    with open(uri_file, \"r\") as fp:\n",
-    "        mpiServerUri = fp.read().rstrip()\n",
-    "        \n",
-    "    return (mpiServer, mpiServerUri)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "uriFile = \"ompi.server.uri\"\n",
-    "\n",
-    "mpiServer, mpiServerUri = create_ompi_server(uriFile)\n",
-    "os.environ[\"OMPI_MCA_pmix_server_uri\"] = mpiServerUri"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +48,7 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3>Client</h3>\n",
        "<ul>\n",
-       "  <li><b>Scheduler: </b>tcp://127.0.0.1:39731\n",
+       "  <li><b>Scheduler: </b>tcp://127.0.0.1:38083\n",
        "  <li><b>Dashboard: </b><a href='http://127.0.0.1:8787/status' target='_blank'>http://127.0.0.1:8787/status</a>\n",
        "</ul>\n",
        "</td>\n",
@@ -115,10 +64,10 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://127.0.0.1:39731' processes=2 cores=2>"
+       "<Client: scheduler='tcp://127.0.0.1:38083' processes=2 cores=2>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,56 +79,251 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import hello_mpi"
+    "from hello_mpi import MPI_World\n",
+    "import random\n",
+    "from dask.distributed import wait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Dask_MPI_Demo:\n",
+    "    \n",
+    "    def __init__(self, client, uriFile = \"ompi.server.uri\" ):\n",
+    "        self.client = client\n",
+    "        self.uriFile = uriFile\n",
+    "        \n",
+    "        print(\"Starting ompi-server\")\n",
+    "        self.create_ompi_server_()\n",
+    "        \n",
+    "    def __dealloc__(self):\n",
+    "        self.mpiServer.kill()\n",
+    "        os.remove(self.uriFile)\n",
+    "    \n",
+    "    def create_ompi_server_(self):\n",
+    "        \n",
+    "        cmd = [\"ompi-server\", \"--no-daemonize\",\"-r\", self.uriFile]\n",
+    "        cmdStr = \"exec \" + \" \".join(cmd)\n",
+    "\n",
+    "        i = inotify.adapters.Inotify()\n",
+    "\n",
+    "        with open(self.uriFile, 'w') as f:\n",
+    "            pass\n",
+    "\n",
+    "        i.add_watch(self.uriFile)\n",
+    "\n",
+    "        proc = subp.Popen(cmdStr, shell=True)\n",
+    "\n",
+    "        # Polls the ompi-server uri file for \n",
+    "        # changes. \n",
+    "        # @todo: Make this robust to failures\n",
+    "        for event in i.event_gen(yield_nones=False):\n",
+    "            (_, type_names, path, filename) = event\n",
+    "            if \"IN_CLOSE_WRITE\" in type_names:\n",
+    "                break\n",
+    "\n",
+    "        i.remove_watch(self.uriFile)\n",
+    "\n",
+    "        mpiServer = proc\n",
+    "        import time\n",
+    "        with open(self.uriFile, \"r\") as fp:\n",
+    "            mpiServerUri = fp.read().rstrip()\n",
+    "\n",
+    "        self.mpiServer = mpiServer\n",
+    "        self.mpiServerUri = mpiServerUri\n",
+    "\n",
+    "        os.environ[\"OMPI_MCA_pmix_server_uri\"] = self.mpiServerUri\n",
+    "\n",
+    "    \n",
+    "    @staticmethod\n",
+    "    def func_parse_host_port_(address):\n",
+    "        if '://' in address:\n",
+    "            address = address.rsplit('://', 1)[1]\n",
+    "        host, port = address.split(':')\n",
+    "        port = int(port)\n",
+    "        return host, port\n",
+    "    \n",
+    "    @staticmethod\n",
+    "    def func_init_(workerId, nWorkers, ompiServerUri):\n",
+    "        if ompiServerUri is None:\n",
+    "            raise Exception(\"ompiServerUri is mandatory!\")\n",
+    "        os.environ[\"OMPI_MCA_pmix_server_uri\"] = ompiServerUri\n",
+    "        w = dask.distributed.get_worker()\n",
+    "        print(\"Hello World! from ip=%s worker=%s/%d uri=%s\" % \\\n",
+    "              (w.address, w.name, nWorkers, ompiServerUri))\n",
+    "        print(\"Worker=%s finished\" % w.name)\n",
+    "\n",
+    "        a = MPI_World(workerId, nWorkers)\n",
+    "        a.init()\n",
+    "        a.create_builder()\n",
+    "\n",
+    "        return a\n",
+    "    \n",
+    "    @staticmethod\n",
+    "    def func_build_session_(world, r):\n",
+    "        world.new_session()\n",
+    "        \n",
+    "    @staticmethod\n",
+    "    def func_open_server_port_(world, r):\n",
+    "        world.open_server_port()\n",
+    "\n",
+    "                \n",
+    "    @staticmethod\n",
+    "    def func_get_server_port_(world, r):\n",
+    "        world.get_server_port()\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def func_connect_to_server_(world, r):\n",
+    "        world.connect_to_server()\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def func_connect_to_client_(world, clientId, r):\n",
+    "        world.connect_to_client(clientId)\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def func_merge_clients_(world, r):\n",
+    "        world.merge_clients()\n",
+    "\n",
+    "        \n",
+    "    @staticmethod\n",
+    "    def func_get_rank_(world, r):\n",
+    "        return world.rank()\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def func_finalize_(world, r):\n",
+    "        world.finalize()\n",
+    "        \n",
+    "        \n",
+    "    def get_workers_(self):\n",
+    "        return list(map(lambda x: Dask_MPI_Demo.func_parse_host_port_(x), self.client.has_what().keys()))\n",
+    "    \n",
+    "    def init(self):\n",
+    "        workers = self.get_workers_()\n",
+    "        workers_indices = list(zip(workers, range(len(workers))))\n",
+    "\n",
+    "        \n",
+    "        w, i = workers_indices[0]\n",
+    "        self.server = self.client.submit(Dask_MPI_Demo.func_init_,\n",
+    "                                               i, len(workers), self.mpiServerUri, workers=[w])\n",
+    "        \n",
+    "        \n",
+    "        self.clients = [(idx, worker, self.client.submit(Dask_MPI_Demo.func_init_, \n",
+    "                                           idx, \n",
+    "                                           len(workers), \n",
+    "                                           self.mpiServerUri, \n",
+    "                                           workers=[worker])) \n",
+    "             for worker, idx in workers_indices[1:]]\n",
+    "                       \n",
+    "        \n",
+    "    def build_session(self):\n",
+    "        \n",
+    "        print(\"Building server\")\n",
+    "                       \n",
+    "        self.client.submit(Dask_MPI_Demo.func_open_server_port_, self.server, random.random()).result()\n",
+    "        [self.client.submit(Dask_MPI_Demo.func_get_server_port_, f, random.random()).result() for i, w, f in self.clients]\n",
+    "\n",
+    "        print(\"Connecting clients to server\")\n",
+    "        for idx, worker, cur_client in self.clients:\n",
+    "            s = self.client.submit(Dask_MPI_Demo.func_connect_to_server_, cur_client, random.random())\n",
+    "            c = self.client.submit(Dask_MPI_Demo.func_connect_to_client_, self.server, idx, random.random())\n",
+    "            \n",
+    "            wait([s, c])\n",
+    "            \n",
+    "        print(\"Merging client ranks\")\n",
+    "        for idx, worker, cur_client in self.clients:\n",
+    "            self.client.submit(Dask_MPI_Demo.func_merge_clients_, cur_client, random.random()).result()\n",
+    "        \n",
+    "    def finalize(self):\n",
+    "        [c.submit(Dask_MPI_Demo.func_finalize_, a, random.random()) for i, w, a in self.clients]\n",
+    "        c.submit(Dask_MPI_Demo.func_finalize_, self.server, random.random())\n",
+    "        self.clients = None\n",
+    "        self.server = None\n",
+    "        \n",
+    "    def get_client_ranks(self):\n",
+    "        return [c.submit(Dask_MPI_Demo.func_get_rank_, a, random.random()).result() for i, w, a in self.clients]\n",
+    "    \n",
+    "    def get_server_rank(self):\n",
+    "        return c.submit(Dask_MPI_Demo.func_get_rank_, self.server, random.random()).result()\n",
+    "        \n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting ompi-server\n"
+     ]
+    }
+   ],
+   "source": [
+    "demo = Dask_MPI_Demo(c)\n",
+    "demo.init()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building server\n",
+      "Connecting clients to server\n",
+      "Merging client ranks\n"
+     ]
+    }
+   ],
    "source": [
-    "def parse_host_port(address):\n",
-    "    if '://' in address:\n",
-    "        address = address.rsplit('://', 1)[1]\n",
-    "    host, port = address.split(':')\n",
-    "    port = int(port)\n",
-    "    return host, port"
+    "demo.build_session()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Client Ranks: [1]\n"
+     ]
+    }
+   ],
    "source": [
-    "def run(workerId, nWorkers, ompiServerUri):\n",
-    "    if ompiServerUri is None:\n",
-    "        raise Exception(\"ompiServerUri is mandatory!\")\n",
-    "    os.environ[\"OMPI_MCA_pmix_server_uri\"] = ompiServerUri\n",
-    "    w = dask.distributed.get_worker()\n",
-    "    print(\"Hello World! from ip=%s worker=%s/%d uri=%s\" % \\\n",
-    "          (w.address, w.name, nWorkers, ompiServerUri))\n",
-    "    print(\"Worker=%s finished\" % w.name)\n",
-    "    \n",
-    "    a = hello_mpi.World(workerId, nWorkers)\n",
-    "    a.init()\n",
-    "\n",
-    "    return a"
+    "print(\"Client Ranks: \" + str(demo.get_client_ranks()))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Server Rank: 0\n"
+     ]
+    }
+   ],
    "source": [
-    "workers = list(zip(map(lambda x: parse_host_port(x), c.has_what().keys()), range(len(c.has_what().keys()))))\n",
-    "f = [c.submit(run, idx, 2, mpiServerUri, workers=[worker]) for worker, idx in workers]\n"
+    "print(\"Server Rank: \" + str(demo.get_server_rank()))"
    ]
   },
   {
@@ -188,64 +332,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import random\n",
-    "\n",
-    "def get_rank(world, r):\n",
-    "    return world.rank()\n",
-    "\n",
-    "def finalize(world):\n",
-    "    world.finalize()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "1\n"
-     ]
-    }
-   ],
-   "source": [
-    "ranks = [c.submit(get_rank, a, random.random()) for a in f]\n",
-    "for i in ranks:\n",
-    "    print(str(i.result()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<Future: status: pending, key: finalize-29b8800f27d460d460363a125011ab3d>,\n",
-       " <Future: status: pending, key: finalize-368dc52407099ed523252fd85db31617>]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "[c.submit(finalize, a) for a in f]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mpiServer.kill()\n",
-    "os.remove(uriFile)"
+    "demo.finalize()"
    ]
   },
   {

--- a/hello-mpi/hello_mpi.pyx
+++ b/hello-mpi/hello_mpi.pyx
@@ -17,14 +17,22 @@ import os
 
 cdef extern from "hello_mpi_c.h" namespace "HelloMPI":
     
-    cdef cppclass MpiWorldBuilder
+    cdef cppclass MpiWorldBuilder:
+        MpiWorldBuilder(int wid, int num)
+        void openServerPort()
+        void getPublishedServerPort()
+        void mergeClients()
+        void connectToServer()
+        void connectToClient(int clientWorkerId)
     
-    MpiWorldBuilder* mpi_run(int workerId, int nWorkers)
+    MpiWorldBuilder *create_builder(int workerId, int nWorkers)
+
     void mpi_init(int workerId)
-    int get_rank(MpiWorldBuilder *comm, int workerId)
     void mpi_finalize(int workerId)
+    int get_rank(MpiWorldBuilder *comm)
+
     
-cdef class World:
+cdef class MPI_World:
     
     cdef MpiWorldBuilder *world
     cdef int workerId
@@ -37,15 +45,36 @@ cdef class World:
         self.init_called = 0
         
     def rank(self):
-        return get_rank(self.world, self.workerId)    
+        return get_rank(self.world)    
 
     def init(self):
         if self.init_called != 0:
             print("Init has already been called!")
         else:
-            self.world = mpi_run(self.workerId, self.nWorkers)
+            mpi_init(self.workerId)
             self.init_called = 1
-
+            
+    def create_builder(self):
+        if self.init_called == 0:
+            print("Must call init() before creating a session")
+        else:
+            self.world = create_builder(self.workerId, self.nWorkers)
+            
+    def open_server_port(self):
+        self.world.openServerPort()
+        
+    def get_server_port(self):
+        self.world.getPublishedServerPort()
+        
+    def connect_to_server(self):
+        self.world.connectToServer()
+        
+    def connect_to_client(self, clientWorkerId):
+        self.world.connectToClient(<int>clientWorkerId)
+        
+    def merge_clients(self):
+        self.world.mergeClients()
+            
     def finalize(self):
         if self.init_called == 0:
             print("Cannot finalize until init has been called")

--- a/hello-mpi/hello_mpi_c.cpp
+++ b/hello-mpi/hello_mpi_c.cpp
@@ -5,150 +5,39 @@
 #include <string>
 #include <stdexcept>
 
-#define THROW(fmt, ...)                                         \
-    do {                                                        \
-        std::string msg;                                        \
-        char errMsg[2048];                                      \
-        sprintf(errMsg, "Exception occured! file=%s line=%d: ", \
-                __FILE__, __LINE__);                            \
-        msg += errMsg;                                          \
-        sprintf(errMsg, fmt, ##__VA_ARGS__);                    \
-        msg += errMsg;                                          \
-        throw std::runtime_error(msg);                          \
-    } while(0)
-
-#define ASSERT(check, fmt, ...)                  \
-    do {                                         \
-        if(!(check))  THROW(fmt, ##__VA_ARGS__); \
-    } while(0)
-
-#define COMM_CHECK(call)                                        \
-  do {                                                          \
-    auto status = call;                                         \
-    ASSERT(status == 0, "FAIL: call='%s'!", #call);             \
-  } while (0)
-
-
 namespace HelloMPI {
 
-class MpiWorldBuilder {
-public:
-    /**
-     * @brief ctor
-     * @param wid worker Id as received from dask world. It thus expects that
-     * the dask-workers have been created with some way of identifying their IDs!
-     * @param num number of workers
-     */
-    MpiWorldBuilder(int wid, int num):
-        workerId(wid), nWorkers(num), portName() {
-        workerId == 0? openPort() : getPort();
-        workerId == 0? connectToClients() : connectToServer();
-    }
-
-    /** dtor */
-    ~MpiWorldBuilder() {
-        if(workerId == 0) {
-            printf("worker=%d: server closing port\n", workerId);
-            COMM_CHECK(MPI_Close_port(portName.c_str()));
-        }
-    }
-
-private:
-    /** current dask worker ID received from python world */
-    int workerId;
-    /** number of workers */
-    int nWorkers;
-    /** port name returned by MPI_Open_port */
-    std::string portName;
-    /** comm handle for all the connected processes so far */
-    MPI_Comm intracomm;
-    /** comm handle for the current newly connected MPI_Comm */
-    MPI_Comm intercomm;
-
-    void openPort() {
-        char _portName[MPI_MAX_PORT_NAME];
-        COMM_CHECK(MPI_Open_port(MPI_INFO_NULL, _portName));
-        portName = _portName;
-        printf("worker=%d port opened on %s\n", workerId, portName.c_str());
-        COMM_CHECK(MPI_Publish_name("server", MPI_INFO_NULL, _portName));
-    }
-
-    void getPort() {
-        sleep(workerId); // wait for the server to publish!
-        char _portName[MPI_MAX_PORT_NAME];
-        COMM_CHECK(MPI_Lookup_name("server", MPI_INFO_NULL, _portName));
-        portName = _portName;
-        printf("worker=%d server port obtained to be %s\n", workerId,
-               portName.c_str());
-    }
-
-    void connectToClients() {
-        for(int i=1;i<nWorkers;++i) {
-            printf("worker=%d: server: trying to connect to client=%d\n",
-                   workerId, i);
-            COMM_CHECK(MPI_Comm_accept(portName.c_str(), MPI_INFO_NULL, 0,
-                                       i == 1? MPI_COMM_WORLD : intracomm,
-                                       &intercomm));
-            printf("worker=%d: server: accepted connection from client=%d\n",
-                   workerId, i);
-            printf("worker=%d: server: merging intercomm\n", workerId);
-            COMM_CHECK(MPI_Intercomm_merge(intercomm, 0, &intracomm));
-            printf("worker=%d: server: intercomm merged\n", workerId);
-            int rank, nranks;
-            MPI_Comm_rank(intracomm, &rank);
-            MPI_Comm_size(intracomm, &nranks);
-            printf("worker=%d: server: after merging from client=%d rank=%d/%d\n",
-                   workerId, i, rank, nranks);
-        }
-    }
-
-    void connectToServer() {
-        printf("worker=%d: client: trying to connect to server %s\n",
-               workerId, portName.c_str());
-        COMM_CHECK(MPI_Comm_connect(portName.c_str(), MPI_INFO_NULL, 0,
-                                    MPI_COMM_WORLD, &intercomm));
-        printf("worker=%d: client: connected to server\n", workerId);
-        printf("worker=%d: client: merging intercomm\n", workerId);
-        COMM_CHECK(MPI_Intercomm_merge(intercomm, 1, &intracomm));
-        printf("worker=%d: client: intercomm is now merged\n", workerId);
-        int rank, nranks;
-        MPI_Comm_rank(intracomm, &rank);
-        MPI_Comm_size(intracomm, &nranks);
-        printf("worker=%d: client: after merging with server rank=%d/%d\n",
-               workerId, rank, nranks);
-        // merge the other workers as well in the clients
-        for(int i=nranks;i<nWorkers;++i) {
-            printf("worker=%d: client: trying to accept for client=%d\n",
-                   workerId, i);
-            COMM_CHECK(MPI_Comm_accept(portName.c_str(), MPI_INFO_NULL, 0,
-                                       intracomm, &intercomm));
-            printf("worker=%d: client: accepted connection from client=%d\n",
-                   workerId, i);
-            printf("worker=%d: client: merging intercomm\n", workerId);
-            COMM_CHECK(MPI_Intercomm_merge(intercomm, 0, &intracomm));
-            printf("worker=%d: client: intercomm is now merged\n", workerId);
-            int rank, nranks;
-            MPI_Comm_rank(intracomm, &rank);
-            MPI_Comm_size(intracomm, &nranks);
-            printf("worker=%d: client: after merging from client=%d rank=%d/%d\n",
-                   workerId, i, rank, nranks);
-        }
-    }
-};
-
-
-void mpi_run(int workerId, int nWorkers) {
+void mpi_init(int workerId) {
+    printf("Init Invoked on %d!\n", workerId);
+}
+    
+MpiWorldBuilder *mpi_run(int workerId, int nWorkers) {
     int rank, nranks;
     MPI_Init(NULL, NULL);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nranks);
     printf("Hello from rank=%d/%d worker=%d/%d\n", rank, nranks, workerId, nWorkers);
     {
-        MpiWorldBuilder builder(workerId, nWorkers);
-        sleep(5);
+        MpiWorldBuilder *builder = new MpiWorldBuilder(workerId, nWorkers);
+        
+        MPI_Comm_rank(builder->intracomm, &rank);
+        printf("Bye from rank=%d/%d worker=%d\n", rank, nranks, workerId);
+        return builder;
     }
-    printf("Bye from rank=%d/%d worker=%d\n", rank, nranks, workerId);
+}
+    
+int get_rank(MpiWorldBuilder *comm, int workerId) {
+    int rank, nranks;
+    MPI_Comm_rank(comm->intracomm, &rank);
+    MPI_Comm_size(comm->intracomm, &nranks);
+    
+    printf("RANK: %d\n", rank);
+    return rank;
+}
+    
+void mpi_finalize(int workerId) {
     MPI_Finalize();
+    printf("Finalize Invoked on %d!\n", workerId);
 }
 
 } // end namespace HelloMPI

--- a/hello-mpi/hello_mpi_c.cpp
+++ b/hello-mpi/hello_mpi_c.cpp
@@ -8,29 +8,39 @@
 namespace HelloMPI {
 
 void mpi_init(int workerId) {
-    printf("Init Invoked on %d!\n", workerId);
-}
     
-MpiWorldBuilder *mpi_run(int workerId, int nWorkers) {
+    printf("Init Invoked on %d!\n", workerId);
+    
+    int flag;
+    MPI_Initialized(&flag);
+    
+    if(flag == 0)
+        MPI_Init(NULL, NULL);
+    else
+        printf("MPI Already Initialized!");
+}
+
+    
+MpiWorldBuilder *create_builder(int workerId, int nWorkers) {
     int rank, nranks;
-    MPI_Init(NULL, NULL);
+    
+    int flag;
+    MPI_Initialized( &flag );
+        
+    printf("Is MPI Initialized? %d\n", flag);
+    
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nranks);
     printf("Hello from rank=%d/%d worker=%d/%d\n", rank, nranks, workerId, nWorkers);
-    {
-        MpiWorldBuilder *builder = new MpiWorldBuilder(workerId, nWorkers);
-        
-        MPI_Comm_rank(builder->intracomm, &rank);
-        printf("Bye from rank=%d/%d worker=%d\n", rank, nranks, workerId);
-        return builder;
-    }
+
+    MpiWorldBuilder *builder = new MpiWorldBuilder(workerId, nWorkers);
+    return builder;
 }
     
-int get_rank(MpiWorldBuilder *comm, int workerId) {
+int get_rank(MpiWorldBuilder *comm) {
     int rank, nranks;
     MPI_Comm_rank(comm->intracomm, &rank);
     MPI_Comm_size(comm->intracomm, &nranks);
-    
     printf("RANK: %d\n", rank);
     return rank;
 }

--- a/hello-mpi/hello_mpi_c.h
+++ b/hello-mpi/hello_mpi_c.h
@@ -37,7 +37,13 @@
 namespace HelloMPI {
 
 class MpiWorldBuilder {
+    
 public:
+
+        
+    /** comm handle for all the connected processes so far */
+    MPI_Comm intracomm;
+
     /**
      * @brief ctor
      * @param wid worker Id as received from dask world. It thus expects that
@@ -46,11 +52,9 @@ public:
      */
     MpiWorldBuilder(int wid, int num):
         workerId(wid), nWorkers(num), portName() {
-        workerId == 0? openPort() : getPort();
-        workerId == 0? connectToClients() : connectToServer();
     }
 
-    /** dtor */
+        /** dtor */
     ~MpiWorldBuilder() {
         if(workerId == 0) {
             printf("worker=%d: server closing port\n", workerId);
@@ -58,57 +62,52 @@ public:
         }
     }
     
-        /** comm handle for all the connected processes so far */
-    MPI_Comm intracomm;
-
-
-private:
-    /** current dask worker ID received from python world */
-    int workerId;
-    /** number of workers */
-    int nWorkers;
-    /** port name returned by MPI_Open_port */
-    std::string portName;
-    /** comm handle for the current newly connected MPI_Comm */
-    MPI_Comm intercomm;
-
-    void openPort() {
+    // First, the server calls this:
+    void openServerPort() {
         char _portName[MPI_MAX_PORT_NAME];
         COMM_CHECK(MPI_Open_port(MPI_INFO_NULL, _portName));
         portName = _portName;
         printf("worker=%d port opened on %s\n", workerId, portName.c_str());
         COMM_CHECK(MPI_Publish_name("server", MPI_INFO_NULL, _portName));
     }
-
-    void getPort() {
-        sleep(1); // wait for the server to publish!
+    
+    // Then, the clients call this:
+    void getPublishedServerPort() {
         char _portName[MPI_MAX_PORT_NAME];
         COMM_CHECK(MPI_Lookup_name("server", MPI_INFO_NULL, _portName));
         portName = _portName;
         printf("worker=%d server port obtained to be %s\n", workerId,
                portName.c_str());
     }
+    
+    // Runs on each client
+    void mergeClients() {
+        
+        int rank, nranks;
+        MPI_Comm_rank(intracomm, &rank);
+        MPI_Comm_size(intracomm, &nranks);
 
-    void connectToClients() {
-        for(int i=1;i<nWorkers;++i) {
-            printf("worker=%d: server: trying to connect to client=%d\n",
+            // merge the other workers as well in the clients
+        for(int i=nranks;i<nWorkers;++i) {
+            printf("worker=%d: client: trying to accept for client=%d\n",
                    workerId, i);
             COMM_CHECK(MPI_Comm_accept(portName.c_str(), MPI_INFO_NULL, 0,
-                                       i == 1? MPI_COMM_WORLD : intracomm,
-                                       &intercomm));
-            printf("worker=%d: server: accepted connection from client=%d\n",
+                                       intracomm, &intercomm));
+            printf("worker=%d: client: accepted connection from client=%d\n",
                    workerId, i);
-            printf("worker=%d: server: merging intercomm\n", workerId);
+            printf("worker=%d: client: merging intercomm\n", workerId);
             COMM_CHECK(MPI_Intercomm_merge(intercomm, 0, &intracomm));
-            printf("worker=%d: server: intercomm merged\n", workerId);
+            printf("worker=%d: client: intercomm is now merged\n", workerId);
             int rank, nranks;
             MPI_Comm_rank(intracomm, &rank);
             MPI_Comm_size(intracomm, &nranks);
-            printf("worker=%d: server: after merging from client=%d rank=%d/%d\n",
+            printf("worker=%d: client: after merging from client=%d rank=%d/%d\n",
                    workerId, i, rank, nranks);
         }
     }
 
+
+    // After getting published server port, clients call this:
     void connectToServer() {
         printf("worker=%d: client: trying to connect to server %s\n",
                workerId, portName.c_str());
@@ -128,29 +127,49 @@ private:
         MPI_Comm_size(intracomm, &nranks);
         printf("worker=%d: client: after merging with server rank=%d/%d\n",
                workerId, rank, nranks);
-        // merge the other workers as well in the clients
-        for(int i=nranks;i<nWorkers;++i) {
-            printf("worker=%d: client: trying to accept for client=%d\n",
-                   workerId, i);
+    }
+
+    // Finally, server connects to the given client
+    void connectToClient(int clientWorkerId) {
+            printf("worker=%d: server: trying to connect to client=%d\n",
+                   workerId, clientWorkerId);
             COMM_CHECK(MPI_Comm_accept(portName.c_str(), MPI_INFO_NULL, 0,
-                                       intracomm, &intercomm));
-            printf("worker=%d: client: accepted connection from client=%d\n",
-                   workerId, i);
-            printf("worker=%d: client: merging intercomm\n", workerId);
+                                       clientWorkerId == 1? MPI_COMM_WORLD : intracomm,
+                                       &intercomm));
+            printf("worker=%d: server: accepted connection from client=%d\n",
+                   workerId, clientWorkerId);
+            printf("worker=%d: server: merging intercomm\n", workerId);
             COMM_CHECK(MPI_Intercomm_merge(intercomm, 0, &intracomm));
-            printf("worker=%d: client: intercomm is now merged\n", workerId);
+            printf("worker=%d: server: intercomm merged\n", workerId);
             int rank, nranks;
             MPI_Comm_rank(intracomm, &rank);
             MPI_Comm_size(intracomm, &nranks);
-            printf("worker=%d: client: after merging from client=%d rank=%d/%d\n",
-                   workerId, i, rank, nranks);
-        }
+            printf("worker=%d: server: after merging from client=%d rank=%d/%d\n",
+                   workerId, clientWorkerId, rank, nranks);
     }
-};
+
     
-MpiWorldBuilder *mpi_run(int workerId, int nWorkers);
+
+
+    
+
+
+
+private:
+    /** current dask worker ID received from python world */
+    int workerId;
+    /** number of workers */
+    int nWorkers;
+    /** port name returned by MPI_Open_port */
+    std::string portName;
+    /** comm handle for the current newly connected MPI_Comm */
+    MPI_Comm intercomm;
+};
+
+MpiWorldBuilder *create_builder(int workerId, int nWorkers);
+
 void mpi_init(int workerId);
 void mpi_finalize(int workerId);
-int get_rank(MpiWorldBuilder *comm,int workerId);
+int get_rank(MpiWorldBuilder *comm);
 
 }; // end namespace HelloMPI

--- a/hello-mpi/hello_mpi_c.h
+++ b/hello-mpi/hello_mpi_c.h
@@ -1,8 +1,156 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string>
+#include <stdexcept>
+
+#define THROW(fmt, ...)                                         \
+    do {                                                        \
+        std::string msg;                                        \
+        char errMsg[2048];                                      \
+        sprintf(errMsg, "Exception occured! file=%s line=%d: ", \
+                __FILE__, __LINE__);                            \
+        msg += errMsg;                                          \
+        sprintf(errMsg, fmt, ##__VA_ARGS__);                    \
+        msg += errMsg;                                          \
+        throw std::runtime_error(msg);                          \
+    } while(0)
+
+#define ASSERT(check, fmt, ...)                  \
+    do {                                         \
+        if(!(check))  THROW(fmt, ##__VA_ARGS__); \
+    } while(0)
+
+#define COMM_CHECK(call)                                        \
+  do {                                                          \
+    auto status = call;                                         \
+    ASSERT(status == 0, "FAIL: call='%s'!", #call);             \
+  } while (0)
+
+
+
+
+
 #pragma once
 
 
 namespace HelloMPI {
 
-void mpi_run(int workerId, int nWorkers);
+class MpiWorldBuilder {
+public:
+    /**
+     * @brief ctor
+     * @param wid worker Id as received from dask world. It thus expects that
+     * the dask-workers have been created with some way of identifying their IDs!
+     * @param num number of workers
+     */
+    MpiWorldBuilder(int wid, int num):
+        workerId(wid), nWorkers(num), portName() {
+        workerId == 0? openPort() : getPort();
+        workerId == 0? connectToClients() : connectToServer();
+    }
+
+    /** dtor */
+    ~MpiWorldBuilder() {
+        if(workerId == 0) {
+            printf("worker=%d: server closing port\n", workerId);
+            COMM_CHECK(MPI_Close_port(portName.c_str()));
+        }
+    }
+    
+        /** comm handle for all the connected processes so far */
+    MPI_Comm intracomm;
+
+
+private:
+    /** current dask worker ID received from python world */
+    int workerId;
+    /** number of workers */
+    int nWorkers;
+    /** port name returned by MPI_Open_port */
+    std::string portName;
+    /** comm handle for the current newly connected MPI_Comm */
+    MPI_Comm intercomm;
+
+    void openPort() {
+        char _portName[MPI_MAX_PORT_NAME];
+        COMM_CHECK(MPI_Open_port(MPI_INFO_NULL, _portName));
+        portName = _portName;
+        printf("worker=%d port opened on %s\n", workerId, portName.c_str());
+        COMM_CHECK(MPI_Publish_name("server", MPI_INFO_NULL, _portName));
+    }
+
+    void getPort() {
+        sleep(1); // wait for the server to publish!
+        char _portName[MPI_MAX_PORT_NAME];
+        COMM_CHECK(MPI_Lookup_name("server", MPI_INFO_NULL, _portName));
+        portName = _portName;
+        printf("worker=%d server port obtained to be %s\n", workerId,
+               portName.c_str());
+    }
+
+    void connectToClients() {
+        for(int i=1;i<nWorkers;++i) {
+            printf("worker=%d: server: trying to connect to client=%d\n",
+                   workerId, i);
+            COMM_CHECK(MPI_Comm_accept(portName.c_str(), MPI_INFO_NULL, 0,
+                                       i == 1? MPI_COMM_WORLD : intracomm,
+                                       &intercomm));
+            printf("worker=%d: server: accepted connection from client=%d\n",
+                   workerId, i);
+            printf("worker=%d: server: merging intercomm\n", workerId);
+            COMM_CHECK(MPI_Intercomm_merge(intercomm, 0, &intracomm));
+            printf("worker=%d: server: intercomm merged\n", workerId);
+            int rank, nranks;
+            MPI_Comm_rank(intracomm, &rank);
+            MPI_Comm_size(intracomm, &nranks);
+            printf("worker=%d: server: after merging from client=%d rank=%d/%d\n",
+                   workerId, i, rank, nranks);
+        }
+    }
+
+    void connectToServer() {
+        printf("worker=%d: client: trying to connect to server %s\n",
+               workerId, portName.c_str());
+        
+        COMM_CHECK(MPI_Comm_connect(portName.c_str(), MPI_INFO_NULL, 0,
+                                    MPI_COMM_WORLD, &intercomm));
+        
+        printf("worker=%d: client: connected to server\n", workerId);
+        printf("worker=%d: client: merging intercomm\n", workerId);
+        
+        
+        COMM_CHECK(MPI_Intercomm_merge(intercomm, 1, &intracomm));
+        
+        printf("worker=%d: client: intercomm is now merged\n", workerId);
+        int rank, nranks;
+        MPI_Comm_rank(intracomm, &rank);
+        MPI_Comm_size(intracomm, &nranks);
+        printf("worker=%d: client: after merging with server rank=%d/%d\n",
+               workerId, rank, nranks);
+        // merge the other workers as well in the clients
+        for(int i=nranks;i<nWorkers;++i) {
+            printf("worker=%d: client: trying to accept for client=%d\n",
+                   workerId, i);
+            COMM_CHECK(MPI_Comm_accept(portName.c_str(), MPI_INFO_NULL, 0,
+                                       intracomm, &intercomm));
+            printf("worker=%d: client: accepted connection from client=%d\n",
+                   workerId, i);
+            printf("worker=%d: client: merging intercomm\n", workerId);
+            COMM_CHECK(MPI_Intercomm_merge(intercomm, 0, &intracomm));
+            printf("worker=%d: client: intercomm is now merged\n", workerId);
+            int rank, nranks;
+            MPI_Comm_rank(intracomm, &rank);
+            MPI_Comm_size(intracomm, &nranks);
+            printf("worker=%d: client: after merging from client=%d rank=%d/%d\n",
+                   workerId, i, rank, nranks);
+        }
+    }
+};
+    
+MpiWorldBuilder *mpi_run(int workerId, int nWorkers);
+void mpi_init(int workerId);
+void mpi_finalize(int workerId);
+int get_rank(MpiWorldBuilder *comm,int workerId);
 
 }; // end namespace HelloMPI


### PR DESCRIPTION
This is a simple demonstration of executing Thejaswi's PoC on a running Dask cluster. In order to run this demonstration, build the `hello_mpi` C++ & Cython as before. Instead of using `launch.py`, run `jupyter lab` in the root directory of the project and execute the cells within `demo.ipynb`

I have separated the `mpi_init + intracomm` construction from the `mpi_finalize` and added a function for members to get their rank from the merged `intracomm`. 

I have exposed the `MPI_Comm` indirectly through cython so that workers can reuse it in subsequent calls. 

This should enable applications within Dask cuML to manage the lifecycle of the comms object as follows:

```
1. Each worker creates a World object and calls initialize(), the pointers to the merged comms objects (local to the workers) for the MPI session is held in futures by the client. 
2. Subsequent calls to those futures enable further communications for the session
.....

N. Eventually finalize is called and the MPI session is destroyed. 
```

Unfortunately, once finalize is called in a session, it seems MPI can no longer be initialized on the workers. If this is correct, the only benefit this approach seems to offer is that the user no longer has to explicitly use `mpirun`. 